### PR TITLE
Add generate executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ differences between each library are reproducibly distinct.
 The script generates a file of 1,000 rows, of 20 fields with `[a-zA-z0-9]` and
 `[," \r\n\t]`, ensuring that the full range of CSV is tested:
 
-    stack ghc -- Generate.hs -o generate && ./generate > in.csv
+    stack exec generate > in.csv
 
 ## file (space)
 

--- a/bench.cabal
+++ b/bench.cabal
@@ -66,3 +66,11 @@ executable report
    , csv
    , vector
    , text
+
+executable generate
+  default-language: Haskell2010
+  ghc-options:      -O2 -rtsopts
+  main-is:          Generate.hs
+  build-depends:
+     base
+   , QuickCheck


### PR DESCRIPTION
## Issue

```
$ stack build
$ stack ghc -- Generate.hs -o generate
```

The command above relies on the fact that there is a QuickCheck library built and cached in the local .stack/snapshots directory.

When it's not the case (you build a fresh LTS snapshot), the command will result in an error:

```
$ stack ghc -- Generate.hs -o generate           
[1 of 1] Compiling Main             ( Generate.hs, Generate.o ) [Test.QuickCheck changed]

Generate.hs:8:1: error:
    Could not find module ‘Test.QuickCheck’
    Use -v to see a list of the files searched for.
  |
8 | import Test.QuickCheck
  | ^^^^^^^^^^^^^^^^^^^^^^
```

Using the 

```
stack exec generate > in.csv
```

solves the problem, and also looks cleaner IMO.